### PR TITLE
chore: enforce code style for imports

### DIFF
--- a/actions.go
+++ b/actions.go
@@ -1,1 +1,0 @@
-package deltalake

--- a/actions/add_test.go
+++ b/actions/add_test.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestAdd_MarshalUnmarshalJSON(t *testing.T) {

--- a/actions/cdc_test.go
+++ b/actions/cdc_test.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCDC_MarshalUnmarshalJSON(t *testing.T) {

--- a/actions/commit_test.go
+++ b/actions/commit_test.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCommitInfo_MarshalUnmarhshalJSON(t *testing.T) {

--- a/actions/metadata_test.go
+++ b/actions/metadata_test.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestMetadata_MarshalUnmarshalJSON(t *testing.T) {

--- a/actions/protocol_test.go
+++ b/actions/protocol_test.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestProtocol_MarshalUnmarshalJSON(t *testing.T) {

--- a/actions/remove_test.go
+++ b/actions/remove_test.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestRemove_MarshalUnmarshalJSON(t *testing.T) {

--- a/actions/transaction_test.go
+++ b/actions/transaction_test.go
@@ -2,8 +2,9 @@ package actions
 
 import (
 	"encoding/json"
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestTransaction_MarshalUnmarshalJSONt(t *testing.T) {

--- a/delta.go
+++ b/delta.go
@@ -15,3 +15,13 @@ func formatVersion(version int64) string {
 func formatPart(part int) string {
 	return fmt.Sprintf("%010d", part)
 }
+
+// CommitURIFromVersion returns the commit URI for the given version.
+// The commit URI is the path to the commit file in the delta log,
+// relative to the root of the table.
+//
+//	uri := CommitURIFromVersion(0)
+//	fmt.Println(uri) // _delta_log/00000000000000000000.json
+func CommitURIFromVersion(version int64) string {
+	return fmt.Sprintf("_delta_log/%s.json", formatVersion(version))
+}

--- a/delta_test.go
+++ b/delta_test.go
@@ -1,0 +1,56 @@
+package deltalake
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCommitURIFromVersion(t *testing.T) {
+	tests := map[string]struct {
+		version int64
+		want    string
+	}{
+		"0": {0, "_delta_log/00000000000000000000.json"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			if got := CommitURIFromVersion(test.version); got != test.want {
+				t.Errorf("CommitURIFromVersion() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func Test_formatPart(t *testing.T) {
+	tests := map[string]struct {
+		part int
+		want string
+	}{
+		"0":         {0, "0000000000"},
+		"MAX_INT32": {math.MaxInt32, "2147483647"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := formatPart(test.part)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func Test_formatVersion(t *testing.T) {
+	tests := map[string]struct {
+		version int64
+		want    string
+	}{
+		"0":         {0, "00000000000000000000"},
+		"MAX_INT64": {math.MaxInt64, "09223372036854775807"},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got := formatVersion(test.version)
+			require.Equal(t, test.want, got)
+		})
+	}
+}

--- a/types/array_test.go
+++ b/types/array_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewArrayType(t *testing.T) {

--- a/types/field_test.go
+++ b/types/field_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewField(t *testing.T) {

--- a/types/map_test.go
+++ b/types/map_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewMapType(t *testing.T) {

--- a/types/struct.go
+++ b/types/struct.go
@@ -25,6 +25,15 @@ func (t *StructType) AddField(field *StructField) {
 	t.Fields = append(t.Fields, field)
 }
 
+func (t *StructType) GetFieldByName(name string) (*StructField, error) {
+	for _, field := range t.Fields {
+		if field.Name == name {
+			return field, nil
+		}
+	}
+	return nil, fmt.Errorf("field %s not found", name)
+}
+
 func (t *StructType) String() string {
 	sb := &strings.Builder{}
 	sb.WriteString("StructType<")

--- a/types/struct_test.go
+++ b/types/struct_test.go
@@ -1,8 +1,9 @@
 package types
 
 import (
-	"github.com/stretchr/testify/require"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewSchema(t *testing.T) {


### PR DESCRIPTION
```go
package main

imports (
	// stdlib
	"errors

	// third-party
	"github.com/stretchr/testify/require"

	// local package
	deltalake/actions
)
```